### PR TITLE
Enable new network policy to allow extension access.

### DIFF
--- a/charts/gardener-extension-cri-resmgr/templates/deployment.yaml
+++ b/charts/gardener-extension-cri-resmgr/templates/deployment.yaml
@@ -32,6 +32,7 @@ spec:
         checksum/gardener-extension-cri-resmgr-imagevector-overwrite: {{ include (print $.Template.BasePath "/configmap-imagevector-overwrite.yaml") . | sha256sum }}
         {{- end }}
       labels:
+        networking.gardener.cloud/to-runtime-apiserver: allowed
         app.kubernetes.io/name: gardener-extension-cri-resmgr
     spec:
       priorityClassName: gardener-extension-cri-resmgr


### PR DESCRIPTION
This access is required for extension to have access to kubernetes apiserver.


Based on this:

https://github.com/gardener/gardener/blob/617075f192ab710c34e893c7d531f0f8f88366a0/docs/operations/network_policies.md#communication-with-kube-apiserver-for-components-in-custom-namespaces
