### PR TITLE
Update .golandci.yml with exclude rule about dot import in tests

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -16,7 +16,5 @@ linters:
     # - golint // Deprecated
   issues:
     exclude-rules:
-    - path: pkg/imagevector/imagevector_suite_test.go
-      text: "should not use dot imports (revive)"
-    - path: pkg/imagevector/imagevector_test.go
+    - path: '(.+)_test\.go'
       text: "should not use dot imports (revive)"

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -14,3 +14,9 @@ linters:
     - staticcheck
     - revive
     # - golint // Deprecated
+  issues:
+    exclude-rules:
+    - path: pkg/imagevector/imagevector_suite_test.go
+      text: "should not use dot imports (revive)"
+    - path: pkg/imagevector/imagevector_test.go
+      text: "should not use dot imports (revive)"


### PR DESCRIPTION
In pkg/imagevector/imagevector_test.go and pkg/imagevector/imagevector_suite_test.go and another's are dot imports. It is required for tests. I created rule to ignore these errors. `Warning: dot-imports: should not use dot imports (revive)` 