### PR TITLE
Commit generated charts.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,5 +8,4 @@ cri-resource-manager-0.6.0.x86_64.tar.gz
 /gardener-extension-cri-resmgr.actuator.test
 /gardener-extension-cri-resmgr.configs.test
 /cmd/gardener-extension-cri-resmgr/__debug_bin
-/pkg/consts/charts
 coverage.*

--- a/Makefile
+++ b/Makefile
@@ -84,20 +84,20 @@ clean-images:
 	docker image rm $(REGISTRY)$(EXTENSION_IMAGE_NAME):$(TAG)
 	docker image rm $(REGISTRY)$(INSTALLATION_IMAGE_NAME):$(TAG)
 
-_build-extension-image:
-	@echo "Building extension image: commit=${COMMIT}${DIRTY} version=${VERSION} target=$(REGISTRY)$(EXTENSION_IMAGE_NAME):$(TAG)"
+regenerate-charts:
 	rm -rf ./pkg/consts/charts
 	go generate ./...
+
+_build-extension-image:
+	@echo "Building extension image: commit=${COMMIT}${DIRTY} version=${VERSION} target=$(REGISTRY)$(EXTENSION_IMAGE_NAME):$(TAG)"
 	docker build --build-arg COMMIT=${COMMIT}${DIRTY} --build-arg VERSION=${VERSION} -t $(REGISTRY)$(EXTENSION_IMAGE_NAME):$(TAG) -f Dockerfile --target $(EXTENSION_IMAGE_NAME) .
 _build-installation-image:
 	@echo "Building installation image: commit=${COMMIT}${DIRTY} version=${VERSION} target=$(REGISTRY)$(INSTALLATION_IMAGE_NAME):$(TAG)"
-	rm -rf ./pkg/consts/charts
-	go generate ./...
 	docker build --build-arg COMMIT=${COMMIT}${DIRTY} --build-arg VERSION=${VERSION} -t $(REGISTRY)$(INSTALLATION_IMAGE_NAME):$(TAG) -f Dockerfile --target $(INSTALLATION_IMAGE_NAME) .
 
 dist: build build-images
 
-build-images: _build-extension-image _build-installation-image
+build-images: regenerate-charts _build-extension-image _build-installation-image
 	echo "Building ${VERSION}-${COMMIT}${DIRTY} done."
 
 

--- a/pkg/consts/charts/gardener-extension-cri-resmgr/Chart.yaml
+++ b/pkg/consts/charts/gardener-extension-cri-resmgr/Chart.yaml
@@ -1,0 +1,21 @@
+# Copyright 2022 Intel Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+name: cri-resmgr-extension
+description: A Helm chart to install cri-resources-manager as extension to Gardener project
+
+type: application
+version: 0.1.0
+appVersion: "1.16.0"

--- a/pkg/consts/charts/gardener-extension-cri-resmgr/templates/_helpers.tpl
+++ b/pkg/consts/charts/gardener-extension-cri-resmgr/templates/_helpers.tpl
@@ -1,0 +1,22 @@
+#
+# Copyright 2022 Intel Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+{{-  define "image" -}}
+  {{- if hasPrefix "sha256:" .Values.image.tag }}
+  {{- printf "%s@%s" .Values.image.repository .Values.image.tag }}
+  {{- else }}
+  {{- printf "%s:%s" .Values.image.repository .Values.image.tag }}
+  {{- end }}
+{{- end }}

--- a/pkg/consts/charts/gardener-extension-cri-resmgr/templates/configmap-configs.yaml
+++ b/pkg/consts/charts/gardener-extension-cri-resmgr/templates/configmap-configs.yaml
@@ -1,0 +1,26 @@
+#
+# Copyright 2022 Intel Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+{{- if .Values.configs }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: gardener-extension-cri-resmgr-configs
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: gardener-extension-cri-resmgr
+data:
+  {{- .Values.configs | toYaml | nindent 2 }}
+{{- end }}

--- a/pkg/consts/charts/gardener-extension-cri-resmgr/templates/configmap-imagevector-overwrite.yaml
+++ b/pkg/consts/charts/gardener-extension-cri-resmgr/templates/configmap-imagevector-overwrite.yaml
@@ -1,0 +1,27 @@
+#
+# Copyright 2022 Intel Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+{{- if .Values.imageVectorOverwrite }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: gardener-extension-cri-resmgr-imagevector-overwrite
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: gardener-extension-cri-resmgr
+data:
+  images_overwrite.yaml: |
+{{ .Values.imageVectorOverwrite | indent 4 }}
+{{- end }}

--- a/pkg/consts/charts/gardener-extension-cri-resmgr/templates/deployment.yaml
+++ b/pkg/consts/charts/gardener-extension-cri-resmgr/templates/deployment.yaml
@@ -1,0 +1,65 @@
+# Copyright 2022 Intel Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: gardener-extension-cri-resmgr
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: gardener-extension-cri-resmgr
+spec:
+  revisionHistoryLimit: 0
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: gardener-extension-cri-resmgr
+  template:
+    metadata:
+      annotations:
+        {{- if .Values.imageVectorOverwrite }}
+        checksum/gardener-extension-cri-resmgr-imagevector-overwrite: {{ include (print $.Template.BasePath "/configmap-imagevector-overwrite.yaml") . | sha256sum }}
+        {{- end }}
+      labels:
+        networking.gardener.cloud/to-runtime-apiserver: allowed
+        app.kubernetes.io/name: gardener-extension-cri-resmgr
+    spec:
+      priorityClassName: gardener-extension-cri-resmgr
+      serviceAccountName: gardener-extension-cri-resmgr
+      containers:
+      - name: gardener-extension-cri-resmgr
+        image: {{ include "image" . }}
+        imagePullPolicy: {{ .Values.image.pullPolicy }}
+        command:
+        - /gardener-extension-cri-resmgr
+        env:
+        - name: EXTENSION_CONFIGMAP_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        - name: LEADER_ELECTION_NAMESPACE
+          value: garden
+{{- if .Values.imageVectorOverwrite }}
+        - name: IMAGEVECTOR_OVERWRITE
+          value: /charts_overwrite/images_overwrite.yaml
+        volumeMounts:
+        - name: imagevector-overwrite
+          mountPath: /charts_overwrite/
+          readOnly: true
+      volumes:
+      - name: imagevector-overwrite
+        configMap:
+          name: gardener-extension-cri-resmgr-imagevector-overwrite
+          defaultMode: 420
+{{- end }}

--- a/pkg/consts/charts/gardener-extension-cri-resmgr/templates/priorityclass.yaml
+++ b/pkg/consts/charts/gardener-extension-cri-resmgr/templates/priorityclass.yaml
@@ -1,0 +1,21 @@
+# Copyright 2022 Intel Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: scheduling.k8s.io/v1
+kind: PriorityClass
+metadata:
+  name: gardener-extension-cri-resmgr
+value: 1000000000
+globalDefault: false
+description: "Priority class for the Gardener extension: cri-resmgr."

--- a/pkg/consts/charts/gardener-extension-cri-resmgr/templates/rbac.yaml
+++ b/pkg/consts/charts/gardener-extension-cri-resmgr/templates/rbac.yaml
@@ -1,0 +1,142 @@
+# Copyright 2022 Intel Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: extensions.gardener.cloud:gardener-extension-cri-resmgr
+  labels:
+    app.kubernetes.io/name: gardener-extension-cri-resmgr
+    app.kubernetes.io/instance: {{ .Release.Name }}
+rules:
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  resourceNames:
+  - kube-apiserver
+  verbs:
+  - get
+  - list
+  - watch
+  - patch
+- apiGroups:
+  - apps
+  resources:
+  - deployments
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - extensions.gardener.cloud
+  resources:
+  - clusters
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - extensions.gardener.cloud
+  resources:
+  - dnsrecords
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - resources.gardener.cloud
+  resources:
+  - managedresources
+  verbs:
+  - "*"
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
+  - extensions.gardener.cloud
+  resources:
+  - extensions
+  - extensions/status
+  verbs:
+  - get
+  - list
+  - watch
+  - patch
+  - update
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - create
+  - list
+  - watch
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  resourceNames:
+  - gardener-extension-heartbeat 
+  verbs:
+  - get
+  - update
+  - patch
+- apiGroups:
+  - ""
+  resources:
+  - configmaps
+  - secrets
+  - events
+  verbs:
+  - "*"
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  verbs:
+  - create
+  - list
+  - watch
+- apiGroups:
+  - coordination.k8s.io
+  resources:
+  - leases
+  resourceNames:
+  - cri-resmgr-leader-election
+  verbs:
+  - update
+  - get
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: extensions.gardener.cloud:gardener-extension-cri-resmgr
+  labels:
+    app.kubernetes.io/name: gardener-extension-cri-resmgr
+    app.kubernetes.io/instance: {{ .Release.Name }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: extensions.gardener.cloud:gardener-extension-cri-resmgr
+subjects:
+- kind: ServiceAccount
+  name: gardener-extension-cri-resmgr
+  namespace: {{ .Release.Namespace }}

--- a/pkg/consts/charts/gardener-extension-cri-resmgr/templates/serviceaccount.yaml
+++ b/pkg/consts/charts/gardener-extension-cri-resmgr/templates/serviceaccount.yaml
@@ -1,0 +1,21 @@
+# Copyright 2022 Intel Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: gardener-extension-cri-resmgr
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: gardener-extension-cri-resmgr

--- a/pkg/consts/charts/gardener-extension-cri-resmgr/templates/vpa.yaml
+++ b/pkg/consts/charts/gardener-extension-cri-resmgr/templates/vpa.yaml
@@ -1,0 +1,22 @@
+{{- if .Values.vpa.enabled}}
+apiVersion: "autoscaling.k8s.io/v1"
+kind: VerticalPodAutoscaler
+metadata:
+  name: gardener-extension-cri-resmgr
+  namespace: {{ .Release.Namespace }}
+spec:
+  {{- if .Values.vpa.resourcePolicy }}
+  resourcePolicy:
+    containerPolicies:
+    - containerName: '*'
+      minAllowed:
+        cpu: {{ required ".Values.vpa.resourcePolicy.minAllowed.cpu is required" .Values.vpa.resourcePolicy.minAllowed.cpu }}
+        memory: {{ required ".Values.vpa.resourcePolicy.minAllowed.memory is required" .Values.vpa.resourcePolicy.minAllowed.memory }}
+  {{- end }}
+  targetRef:
+    apiVersion: apps/v1
+    kind: Deployment
+    name: gardener-extension-cri-resmgr
+  updatePolicy:
+    updateMode: {{ .Values.vpa.updatePolicy.updateMode }}
+{{- end }}

--- a/pkg/consts/charts/gardener-extension-cri-resmgr/values.yaml
+++ b/pkg/consts/charts/gardener-extension-cri-resmgr/values.yaml
@@ -1,0 +1,53 @@
+# Copyright 2022 Intel Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+replicaCount: 1
+
+heartbeat: 
+    renewIntervalSeconds: 30 
+
+### This is default value for extension image to be tested with kind-based provided local with Gardener above 1.55.0
+### If you want to overwrite it, please provide values to ControllerDeployment providerConfig.values.
+image:
+  repository: localhost:5001/gardener-extension-cri-resmgr
+  tag: latest
+  pullPolicy: Always
+
+vpa:
+  enabled: true
+  resourcePolicy:
+    minAllowed:
+      cpu: 10m
+      memory: 64Mi
+  updatePolicy:
+    updateMode: "Auto"
+
+### NOTE: The values provided here are only for development/testing purposes as an example.
+### Default values, defined in charts.go package by embedding charts/images.yaml, are the "source of truth".
+### Please do not uncomment those, unless you want to just try "helm template ." without extension.
+# imageVectorOverwrite: |
+#   images:
+#   - name: gardener-extension-cri-resmgr-installation
+#     tag: latest
+#     repository: localhost:5001/gardener-extension-cri-resmgr-installation
+#   - name: gardener-extension-cri-resmgr-agent
+#     tag: latest
+#     repository: localhost:5001/gardener-extension-cri-resmgr-agent
+# configs:
+#   fallback: |
+#     policy:
+#       Active: "fallback"
+#   default: |
+#     policy:
+#       Active: "default"

--- a/pkg/consts/charts/images.go
+++ b/pkg/consts/charts/images.go
@@ -1,0 +1,22 @@
+// Copyright 2022 Intel Corporation. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package charts
+
+import _ "embed" // Add embed to import yaml
+
+// ImagesYAML contains the contents of the images.yaml file.
+//
+//go:embed images.yaml
+var ImagesYAML string

--- a/pkg/consts/charts/images.yaml
+++ b/pkg/consts/charts/images.yaml
@@ -1,0 +1,25 @@
+#
+# Copyright 2022 Intel Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Default values for image location internal installation and agent. Use localhost:5001 (local provider registry) until images will be published.
+images:
+- name: gardener-extension-cri-resmgr-installation
+  sourceRepository: https://github.com/intel/gardener-extension-cri-resmgr
+  repository: localhost:5001/gardener-extension-cri-resmgr-installation-and-agent
+  tag: latest
+- name: gardener-extension-cri-resmgr-agent
+  sourceRepository: https://github.com/intel/cri-resource-manager
+  repository: localhost:5001/gardener-extension-cri-resmgr-installation-and-agent
+  tag: latest

--- a/pkg/consts/charts/internal/cri-resmgr-installation/.helmignore
+++ b/pkg/consts/charts/internal/cri-resmgr-installation/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/pkg/consts/charts/internal/cri-resmgr-installation/Chart.yaml
+++ b/pkg/consts/charts/internal/cri-resmgr-installation/Chart.yaml
@@ -1,0 +1,19 @@
+# Copyright 2022 Intel Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+name: cri-resmgr-installation
+type: application
+version: 0.2.0
+appVersion: "latest"

--- a/pkg/consts/charts/internal/cri-resmgr-installation/templates/agent-adjustment-schema.yaml
+++ b/pkg/consts/charts/internal/cri-resmgr-installation/templates/agent-adjustment-schema.yaml
@@ -1,0 +1,100 @@
+#
+# Copyright 2022 Intel Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: adjustments.criresmgr.intel.com
+spec:
+  group: criresmgr.intel.com
+  names:
+    kind: Adjustment
+    singular: adjustment
+    plural: adjustments
+  scope: Namespaced
+  versions:
+    - name: v1alpha1
+      served: true
+      storage: true
+      schema:
+        # openAPI V3 Schema for validating adjustments
+        openAPIV3Schema:
+          type: object
+          required: [ spec ]
+          properties:
+            spec:
+              type: object
+              required: [ scope ]
+              properties:
+                scope:
+                  type: array
+                  items:
+                    type: object
+                    properties:
+                      nodes:
+                        type: array
+                        items:
+                          type: string
+                      containers:
+                        type: array
+                        items:
+                          type: object
+                          properties:
+                            key:
+                              type: string
+                            operator:
+                              type: string
+                            values:
+                              type: array
+                              items:
+                                type: string
+                resources:
+                  type: object
+                  properties:
+                    requests:
+                      type: object
+                      properties:
+                        cpu:
+                          type: string
+                        memory:
+                          type: string
+                    limits:
+                      type: object
+                      properties:
+                        cpu:
+                          type: string
+                        memory:
+                          type: string
+                classes:
+                  type: object
+                  properties:
+                    rdt:
+                      type: string
+                    blockio:
+                      type: string
+                toptierLimit:
+                  type: string
+            status:
+              type: object
+              properties:
+                nodes:
+                  type: object
+                  additionalProperties:
+                    type: object
+                    properties:
+                      errors:
+                        type: object
+                        additionalProperties:
+                          type: string

--- a/pkg/consts/charts/internal/cri-resmgr-installation/templates/agent-deployment.yaml
+++ b/pkg/consts/charts/internal/cri-resmgr-installation/templates/agent-deployment.yaml
@@ -1,0 +1,141 @@
+#
+# Copyright 2022 Intel Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: cri-resmgr-agent
+  namespace: kube-system
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: cri-resmgr-agent
+rules:
+- apiGroups:
+  - ""
+  - criresmgr.intel.com
+  resources:
+  - nodes
+  - configmaps
+  - adjustments
+  - labels
+  - annotations
+  verbs:
+  - get
+  - patch
+  - update
+  - watch
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: cri-resmgr-agent
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: cri-resmgr-agent
+subjects:
+- kind: ServiceAccount
+  name: cri-resmgr-agent
+  namespace: kube-system
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  labels:
+    app: cri-resmgr-agent
+  name: cri-resmgr-agent
+  namespace: kube-system
+spec:
+  selector:
+    matchLabels:
+      app: cri-resmgr-agent
+  template:
+    metadata:
+      labels:
+        app: cri-resmgr-agent
+        gardener.cloud/role: system-component
+    spec:
+      hostPID: true
+      hostIPC: true
+      serviceAccount: cri-resmgr-agent
+      # only install to nodes with containerd
+      nodeSelector:
+{{ toYaml .Values.nodeSelector | indent 8 }}
+      containers:
+        - name: cri-resmgr-agent
+          env:
+          - name: NODE_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: spec.nodeName
+          image: {{ index .Values.images "gardener-extension-cri-resmgr-agent" }}
+          imagePullPolicy: Always # for testing
+          command: ["/scripts/install-cri-resmgr.sh"]
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
+              add:
+              - SYS_CHROOT
+            resources:
+              requests:
+                cpu: 100m
+            readOnlyRootFilesystem: true
+          volumeMounts:
+          - name: resmgrsockets
+            mountPath: /var/run/cri-resmgr
+          - name: host-volume
+            mountPath: /var/host
+          - name: host-volume-var-run-cri-resmgr
+            mountPath: /var-run-cri-resmgr
+            path: /var/run/cri-resmgr/
+          - name: cri-resmgr-installation-script
+            mountPath: /scripts
+          resources:
+            limits:
+              cpu: 100m
+              memory: 512Mi
+          readinessProbe:
+            exec:
+              command: ["/bin/cri-resmgr-agent-probe", "-query", "config-status"]
+            initialDelaySeconds: 5
+            periodSeconds: 30
+          readinessProbe:
+            exec:
+              command: ["chroot", "/var/host", "bash", "-c", "systemctl status cri-resource-manager", "&&", "/bin/cri-resmgr-agent-probe", "-query", "config-status"]
+            failureThreshold: 1
+            initialDelaySeconds: 10
+            periodseconds: 30
+          livenessProbe:
+            exec:
+              command: ["/bin/cri-resmgr-agent-probe"]
+            initialDelaySeconds: 5
+            periodSeconds: 30
+      volumes:
+      - name: resmgrsockets
+        hostPath:
+          path: /var/run/cri-resmgr
+      - name: host-volume
+        hostPath:
+          path: /
+      - name: host-volume-var-run-cri-resmgr
+        hostPath:
+          path: /var/run/cri-resmgr/
+      - name: cri-resmgr-installation-script
+        configMap:
+          name: cri-resmgr-installation-script
+          defaultMode: 0744

--- a/pkg/consts/charts/internal/cri-resmgr-installation/templates/installation-configmap.yaml
+++ b/pkg/consts/charts/internal/cri-resmgr-installation/templates/installation-configmap.yaml
@@ -1,0 +1,104 @@
+# Copyright 2022 Intel Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cri-resmgr-installation-script
+  namespace: kube-system
+data:
+  install-cri-resmgr.sh: |-
+    #!/bin/bash
+    # check if kubelet service file is a symlink
+    if [[ -L "/var/host/etc/systemd/system/kubelet.service" ]]; then
+      echo "err: kubelet.service file is a symlink"
+      exit 1
+    fi
+    function install() {
+
+      echo "*** Installation start ($(cat /VERSION)-$(cat /COMMIT))"
+      echo Installing binaries from /opt/ to host /
+      cp -v -r /cri-resmgr-installation/opt/ /var/host/
+
+      echo Installing systemd unit
+      cp -v /cri-resmgr-installation/etc/systemd/system/cri-resource-manager.service  /var/host/etc/systemd/system/cri-resource-manager.service
+
+      echo 'Installing systemd unit config file (contains POLICY_OPTIONS and CONFIG_OPTIONS variables - pointing to fallback.cfg)'
+      mkdir -p /var/host/etc/default/
+      cp -v /cri-resmgr-installation/etc/default/cri-resource-manager /var/host/etc/default/
+
+      echo 'Installing cri-resource manager with null policy'
+      mkdir -p /var/host/etc/cri-resmgr
+      cp -v /cri-resmgr-installation/etc/cri-resmgr/fallback.cfg.sample /var/host/etc/cri-resmgr/fallback.cfg
+      sed -i 's/topology-aware/null/g' /var/host/etc/cri-resmgr/fallback.cfg
+
+      # Handle EXTRA_OPTIONS
+      if [[ -f /etc/cri-resmgr/EXTRA_OPTIONS.cfg ]]; then
+        echo 'Installing EXTRA_OPTIONS configuration file from /etc/cri-resmgr/EXTRA_OPTIONS to host /etc/cri-resmgr/'
+        cp -v /etc/cri-resmgr/EXTRA_OPTIONS.cfg /var/host/etc/cri-resmgr/EXTRA_OPTIONS.cfg
+        echo 'Modify cri-resource-manager.service to include EXTRA_OPTIONS when starting cri-resmgr binary!'
+        sed -i 's!\$POLICY_OPTIONS$!\$POLICY_OPTIONS \$EXTRA_OPTIONS!' /var/host/etc/systemd/system/cri-resource-manager.service
+        sed -z -i 's!EnvironmentFile=/etc/default/cri-resource-manager\nExecStart!EnvironmentFile=/etc/default/cri-resource-manager\nEnvironmentFile=/etc/cri-resmgr/EXTRA_OPTIONS.cfg\nExecStart!' /var/host/etc/systemd/system/cri-resource-manager.service
+      else 
+        if [[ -f /var/host/etc/cri-resmgr/EXTRA_OPTIONS ]]; then
+          echo 'Remove EXTRA_OPTIONS.cfg file from host'
+          rm -v /var/host/etc/cri-resmgr/EXTRA_OPTIONS.cfg
+        fi
+        echo 'Modify cri-resource-manager.service to remove EXTRA_OPTIONS when starting cri-resmgr binary!'
+        sed -z -i 's!EnvironmentFile=/etc/default/cri-resource-manager\nEnvironmentFile=/etc/cri-resmgr/EXTRA_OPTIONS.cfg\n!EnvironmentFile=/etc/default/cri-resource-manager\n!' /var/host/etc/systemd/system/cri-resource-manager.service
+        sed -i 's!\$POLICY_OPTIONS \$EXTRA_OPTIONS$!\$POLICY_OPTIONS!' /var/host/etc/systemd/system/cri-resource-manager.service
+      fi
+
+      # Warning if previous state exists
+      if [[ -d /var/host/var/lib/cri-resmgr ]]; then
+        echo 'WARNING! previous state of cri-resmgr still exists in hosts /var/lib/cri-resmgr!'
+        echo '         cri-resource-manager was not properly uninstalled, cached config will be used instead of fallback.cfg'
+        echo '         To fix just restart this pod or manually remove /var/lib/cri-resmgr on host.'
+      fi
+
+      echo Enable and restart cri-resource-manager systemd unit.
+      chroot /var/host bash -c "systemctl enable cri-resource-manager"
+      chroot /var/host bash -c "systemctl restart cri-resource-manager"
+
+      echo Reconfigure kubelet.service to use connect to cri-resmgr.sock as container-runtime
+      sed -i  '/containerd/d' /var/host/etc/systemd/system/kubelet.service
+      if ! grep -q container-runtime-endpoint  "/var/host/etc/systemd/system/kubelet.service"; then
+        # matches GardenLinux kubelet config
+        sed '/KUBELET_EXTRA_ARGS \\/ s!$!\n    --container-runtime-endpoint=/var/run/cri-resmgr/cri-resmgr.sock\\!' -i /var/host/etc/systemd/system/kubelet.service
+        # matches kind-node kubelet config
+        sed '/KUBELET_EXTRA_ARGS$/ s!$! \\\n    --container-runtime-endpoint=/var/run/cri-resmgr/cri-resmgr.sock\\!' -i /var/host/etc/systemd/system/kubelet.service
+      fi
+      echo Wait for cri-resource-manager, container and kubelet services to be active
+      # Check if cri-resource-manager, containerd and kubelet is active
+      while true; do
+          criIsActive=$(chroot /var/host bash -c "systemctl is-active cri-resource-manager")
+          containerdIsActive=$(chroot /var/host bash -c "systemctl is-active containerd")
+          kubeletIsActive=$(chroot /var/host bash -c "systemctl is-active kubelet")
+          if [ "$criIsActive" == "active" ] && [ "$containerdIsActive" == "active" ] && [ "$kubeletIsActive" == "active" ];then
+              break
+          fi
+          sleep 1
+      done
+      echo "*** Restart kubelet with new configuration"
+      sleep 2
+      chroot /var/host bash -c "systemctl daemon-reload"
+      chroot /var/host bash -c "systemctl restart kubelet"
+      # Don't wait for activation - we will run check at the of the script
+
+      echo "Start cri-resmgr-agent"
+      /bin/cri-resmgr-agent
+    }
+
+    # Install cri-rm and run the agent
+    install

--- a/pkg/consts/charts/internal/cri-resmgr-installation/templates/installation-configs-dynamic.yaml
+++ b/pkg/consts/charts/internal/cri-resmgr-installation/templates/installation-configs-dynamic.yaml
@@ -1,0 +1,30 @@
+# Copyright 2022 Intel Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+{{/* dynamic configuration have different form than static configs - are read by cri-agent */}}
+{{- range $configName, $configContent := (.Values.configs | default dict).dynamic }}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  namespace: kube-system
+  name: "cri-resmgr-config.{{ $configName }}"
+data:
+{{- $configObject := fromYaml $configContent }}
+{{- range $configKey, $configValue := $configObject }}
+  {{ $configKey }}: |
+    {{- $configValue | toYaml | nindent 4 }}
+{{- end }}
+---
+
+{{- end }}

--- a/pkg/consts/charts/internal/cri-resmgr-installation/templates/installation-service.yaml
+++ b/pkg/consts/charts/internal/cri-resmgr-installation/templates/installation-service.yaml
@@ -1,0 +1,28 @@
+# Copyright 2022 Intel Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+apiVersion: v1
+kind: Service
+metadata:
+  name: cri-resmgr-installation
+  namespace: kube-system
+spec:
+  selector:
+    app.kubernetes.io/name: cri-resmgr-installation
+  ports:
+    - name: metrics
+      protocol: TCP
+      port: 8891
+      targetPort: 8891

--- a/pkg/consts/charts/internal/cri-resmgr-installation/values.yaml
+++ b/pkg/consts/charts/internal/cri-resmgr-installation/values.yaml
@@ -1,0 +1,42 @@
+# Copyright 2022 Intel Corporation. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+### Only uncomment for testing with "helm template "
+### Comment before merging to master!
+### - "images" will be taken from from chart/images.{go,yaml} and should be enough and only one source of truth.
+###            or can be overwritten with imageVectorOverwrite in ControllerDeployment
+### - "configs" will be provided from configMap or Shoot.Spec.Extensions.providerConfig
+### - "nodeSelector" will be provided by spec.Shoot.providerConfig and default one forcing of using containerd as CRI runtime
+#images:
+#  gardener-extension-cri-resmgr-installation: localhost:5001/gardener-extension-cri-resmgr-installation:latest
+#  gardener-extension-cri-resmgr-agent: localhost:5001/gardener-extension-cri-resmgr-agent:latest
+#
+#configs:
+#  static:
+#    force: |
+#      policy:
+#        Active: "force"
+#    fallback: |
+#      policy:
+#        Active: "fallback"
+#  dynamic:
+#    default: |
+#      policy:
+#        Active: "default"
+#    nodeFoo: |
+#      policy:
+#        Active: "nodeFoo"
+#
+#nodeSelector:
+#  foo: bar


### PR DESCRIPTION
Required to automate build docker images.

Includes:
- new target in Makefile (regenerate-charts)
